### PR TITLE
동작하지 않는 anchor 수정

### DIFF
--- a/pages/Advanced Types.md
+++ b/pages/Advanced Types.md
@@ -1,6 +1,6 @@
 # 목차 (Table of contents)
 
-[교차 타입 (Intersection Types)](#교차-타입-Intersection-Types)
+[교차 타입 (Intersection Types)](#교차-타입-intersection-types)
 
 [유니언 타입 (Union Types)](#유니언-타입-union-types)
 


### PR DESCRIPTION
- [typescript-kr : advanced-types](https://typescript-kr.github.io/pages/Advanced%20Types.htmll) 의 교차 타입 anchor 가 동작하지 않습니다.
- 깃북: 소문자만 동작 / 깃헙: 대, 소문자 모두 동작  하기 때문에 소문자로 수정합니다.