### PR TITLE
typescript-in-5-minutes 다운로드 안내 링크 수정

### DIFF
--- a/pages/tutorials/TypeScript in 5 minutes.md
+++ b/pages/tutorials/TypeScript in 5 minutes.md
@@ -8,7 +8,7 @@ TypeScript를 설치하는 방법에는 크게 두 가지가 있습니다:
 * TypeScript의 Visual Studio 플러그인 설치
 
 Visual Studio 2017과 Visual Studio 2015 Update 3는 기본적으로 Typescript를 포함하고 있습니다.
-만약 TypeScript를 Visual Studio과 함께 설치하지 않았다면 [이곳에서 다운로드](/#download-links)할 수 있습니다.
+만약 TypeScript를 Visual Studio과 함께 설치하지 않았다면 [이곳에서 다운로드](https://www.typescriptlang.org/download)할 수 있습니다.
 
 NPM 사용자의 경우:
 


### PR DESCRIPTION
- [tutorials/TypeScript in 5 minutes](https://typescript-kr.github.io/pages/tutorials/TypeScript%20in%205%20minutes.html) 의 typescript 설치 안내 링크가 제대로 동작하지 않습니다.
- 다운로드 안내 링크 경로가 현재 레포에는 존재하지 않아서 [원문 링크](https://www.typescriptlang.org/download)로 수정해보았습니다.

리뷰 부탁드립니다!!