### PR TITLE
package.json의 script에 pretest부분을 추가함

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typescript": "^3.8.3"
   },
   "scripts": {
+    "prebuild": "rm -rf bin",
     "pretest": "npm run build",
     "test": "npx markdownlint . && node ./bin/lint '**/*.md'",
     "lint": "npm run test",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "typescript": "^3.8.3"
   },
   "scripts": {
+    "pretest": "npm run build",
     "test": "npx markdownlint . && node ./bin/lint '**/*.md'",
     "lint": "npm run test",
     "lint-beta": "npm run build && node ./bin/lint '**/*.md'",


### PR DESCRIPTION
현재 `package.json`에 존재하는 `script` 부분 중, `test`부분이 다음과 같은 스크립트를 실행시킵니다.

`"test": "npx markdownlint . && node ./bin/lint '**/*.md'"`

`test` 스크립트는 현재 `npm run build`와 같은 스크립트를 커버하지 못하고 있어서 문제가 되고 있으며 이를 해결하기 위해 `pretest` 스크립트를 추가하고 해당 내용에 `build`와 관련된 내용을 추가했습니다.